### PR TITLE
bind docker compose services to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
     command: >-
         --jit=false
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"


### PR DESCRIPTION
We don't want to expose the dev services to public

Note:
firewalls doesn't block access because docker overwrites the firewall settings
