### PR TITLE
fix typing_extensions error, fix Deprecation warnings

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,7 +24,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   db:
     restart: always
-    image: postgres:12.3
+    image: postgres:16
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_USER: "postgres"

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,13 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Fixed
+
+- `typing_extensions` errors on python >= 3.10.
+- Address deprecation warnings in tests.
+
 ## 0.10.2
 
 ### Changed

--- a/lilya/_internal/_parsers.py
+++ b/lilya/_internal/_parsers.py
@@ -12,8 +12,8 @@ from lilya.datastructures import DataUpload, FormData, Header
 from lilya.enums import FormMessage
 
 try:
-    import multipart
-    from multipart.multipart import parse_options_header
+    import python_multipart as multipart
+    from python_multipart.multipart import parse_options_header
 except ModuleNotFoundError:  # pragma: nocover
     parse_options_header = None
     multipart = None

--- a/lilya/_internal/_parsers.py
+++ b/lilya/_internal/_parsers.py
@@ -15,8 +15,13 @@ try:
     import python_multipart as multipart
     from python_multipart.multipart import parse_options_header
 except ModuleNotFoundError:  # pragma: nocover
-    parse_options_header = None
-    multipart = None
+    # old import name
+    try:
+        import multipart  # type: ignore[no-redef]
+        from multipart.multipart import parse_options_header  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: nocover
+        parse_options_header = None
+        multipart = None
 
 
 @lru_cache(1024)

--- a/lilya/_utils.py
+++ b/lilya/_utils.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from inspect import isclass
-from typing import Any
-
-from typing_extensions import get_origin
+from typing import Any, get_origin
 
 
 def is_class_and_subclass(value: Any, _type: Any) -> bool:

--- a/lilya/apps.py
+++ b/lilya/apps.py
@@ -5,8 +5,6 @@ from collections.abc import Awaitable, Mapping, Sequence
 from functools import cached_property
 from typing import Annotated, Any, Callable, cast
 
-from typing_extensions import Doc
-
 from lilya._internal._module_loading import import_string
 from lilya._utils import is_class_and_subclass
 from lilya.conf import __lazy_settings__, settings as lilya_settings
@@ -27,6 +25,7 @@ from lilya.types import (
     ApplicationType,
     ASGIApp,
     CallableDecorator,
+    Doc,
     ExceptionHandler,
     Lifespan,
     Receive,

--- a/lilya/cli/directives/operations/runserver.py
+++ b/lilya/cli/directives/operations/runserver.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import click
 
 from lilya.cli.env import DirectiveEnv
 from lilya.cli.exceptions import DirectiveError
 from lilya.cli.terminal import OutputColour, Print, Terminal
-
 
 printer = Print()
 terminal = Terminal()
@@ -106,9 +105,9 @@ def runserver(
     server_environment: str = ""
     if os.environ.get("LILYA_SETTINGS_MODULE"):
         from lilya.conf import settings as lilya_settings
-        
+
         server_environment = f"{lilya_settings.environment} "
-    
+
     app = env.app
     message = terminal.write_info(
         f"Starting {server_environment}server @ {host} server @ {host}",

--- a/lilya/conf/global_settings.py
+++ b/lilya/conf/global_settings.py
@@ -6,10 +6,9 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, ClassVar
 
 from dymmond_settings import Settings as BaseSettings
 from dymmond_settings.enums import EnvironmentType
-from typing_extensions import Doc
 
 from lilya import __version__
-from lilya.types import ApplicationType, ASGIApp, ExceptionHandler
+from lilya.types import ApplicationType, ASGIApp, Doc, ExceptionHandler
 
 if TYPE_CHECKING:
     from lilya.middleware.base import DefineMiddleware

--- a/lilya/context.py
+++ b/lilya/context.py
@@ -4,10 +4,8 @@ import copy
 import warnings
 from typing import TYPE_CHECKING, Annotated, Any
 
-from typing_extensions import Doc
-
 from lilya.datastructures import URL
-from lilya.types import Scope
+from lilya.types import Doc, Scope
 
 if TYPE_CHECKING:
     from lilya.requests import Request

--- a/lilya/middleware/authentication.py
+++ b/lilya/middleware/authentication.py
@@ -4,12 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Annotated, Any
 
-from typing_extensions import Doc
-
 from lilya._internal._connection import Connection
 from lilya.enums import ScopeType
 from lilya.protocols.middleware import MiddlewareProtocol
-from lilya.types import ASGIApp, Receive, Scope, Send
+from lilya.types import ASGIApp, Doc, Receive, Scope, Send
 
 
 @dataclass

--- a/lilya/protocols/authentication.py
+++ b/lilya/protocols/authentication.py
@@ -7,9 +7,7 @@ if sys.version_info >= (3, 10):  # pragma: no cover
 else:  # pragma: no cover
     from typing_extensions import ParamSpec
 
-from typing import Any, runtime_checkable
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from lilya._internal._connection import Connection
 from lilya.types import ASGIApp, Receive, Scope, Send

--- a/lilya/protocols/middleware.py
+++ b/lilya/protocols/middleware.py
@@ -7,9 +7,7 @@ if sys.version_info >= (3, 10):  # pragma: no cover
 else:  # pragma: no cover
     from typing_extensions import ParamSpec
 
-from typing import runtime_checkable
-
-from typing_extensions import Protocol
+from typing import Protocol, runtime_checkable
 
 from lilya.types import ASGIApp, Receive, Scope, Send
 

--- a/lilya/protocols/permissions.py
+++ b/lilya/protocols/permissions.py
@@ -7,9 +7,7 @@ if sys.version_info >= (3, 10):  # pragma: no cover
 else:  # pragma: no cover
     from typing_extensions import ParamSpec
 
-from typing import runtime_checkable
-
-from typing_extensions import Protocol
+from typing import Protocol, runtime_checkable
 
 from lilya.types import ASGIApp, Receive, Scope, Send
 

--- a/lilya/requests.py
+++ b/lilya/requests.py
@@ -23,7 +23,11 @@ from lilya.types import Empty, Message, Receive, Scope, Send
 try:
     from python_multipart.multipart import parse_options_header
 except ModuleNotFoundError:  # pragma: nocover
-    parse_options_header = None
+    # old import name
+    try:
+        from multipart.multipart import parse_options_header  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: nocover
+        parse_options_header = None
 
 
 class Request(Connection):

--- a/lilya/requests.py
+++ b/lilya/requests.py
@@ -21,7 +21,7 @@ from lilya.exceptions import HTTPException
 from lilya.types import Empty, Message, Receive, Scope, Send
 
 try:
-    from multipart.multipart import parse_options_header
+    from python_multipart.multipart import parse_options_header
 except ModuleNotFoundError:  # pragma: nocover
     parse_options_header = None
 

--- a/lilya/routing.py
+++ b/lilya/routing.py
@@ -7,8 +7,6 @@ import traceback
 from collections.abc import Awaitable, Mapping, Sequence
 from typing import Annotated, Any, Callable, TypeVar, cast
 
-from typing_extensions import Doc
-
 from lilya import status
 from lilya._internal._events import AsyncLifespan, handle_lifespan_events
 from lilya._internal._module_loading import import_string
@@ -31,14 +29,7 @@ from lilya.middleware.base import DefineMiddleware
 from lilya.permissions.base import DefinePermission
 from lilya.requests import Request
 from lilya.responses import PlainText, RedirectResponse, Response
-from lilya.types import (
-    ASGIApp,
-    ExceptionHandler,
-    Lifespan,
-    Receive,
-    Scope,
-    Send,
-)
+from lilya.types import ASGIApp, Doc, ExceptionHandler, Lifespan, Receive, Scope, Send
 from lilya.websockets import WebSocket, WebSocketClose
 
 T = TypeVar("T")

--- a/lilya/types.py
+++ b/lilya/types.py
@@ -12,8 +12,8 @@ try:
 except ModuleNotFoundError:
     # stub
 
-    class Doc:
-        def __init__(self, documentation, /) -> None:
+    class Doc:  # type: ignore[no-redef]
+        def __init__(self, documentation: str, /) -> None:
             self.documentation = documentation
 
 

--- a/lilya/types.py
+++ b/lilya/types.py
@@ -7,6 +7,16 @@ from typing import (
     Union,
 )
 
+try:
+    from typing_extensions import Doc
+except ModuleNotFoundError:
+    # stub
+
+    class Doc:
+        def __init__(self, documentation, /) -> None:
+            self.documentation = documentation
+
+
 ApplicationType = TypeVar("ApplicationType")
 
 Scope = MutableMapping[str, Any]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "anyio>=3.4.0,<5",
     "dymmond-settings>=1.0.5",
     "multidict>=6.0.4,<7.0.0",
-    "typing_extensions>=3.10.0; python_version < '3.10'",
+    "typing_extensions>=3.10.0",
 ]
 keywords = ["lilya"]
 
@@ -147,7 +147,6 @@ new_lang = "hatch run docs:update_languages; scripts/docs.py new-lang --lang {ar
 
 [tool.hatch.envs.test]
 features = ['testing', "cli"]
-template = "test"
 installer = "pip"
 
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "anyio>=3.4.0,<5",
     "dymmond-settings>=1.0.5",
     "multidict>=6.0.4,<7.0.0",
-    "typing_extensions>=3.10.0",
+    "typing_extensions>=3.10.0; python_version < '3.10'",
 ]
 keywords = ["lilya"]
 
@@ -90,9 +90,9 @@ testing = [
     "pytest-asyncio>=0.23.2",
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-mock>=3.12.0",
-    "python-multipart>=0.0.12",
-    "requests>=2.28.2",
+    "python-multipart>=0.0.13",
     "mypy==1.10.0",
+    "typing_extensions>=3.10.0",
     "ipython",
     "ptpython",
     "ipdb",
@@ -109,6 +109,7 @@ docs = [
     "mkdocs-meta-descriptions-plugin>=2.3.0",
     "mkdocstrings[python]>=0.23.0,<0.30.0",
     "pyyaml>=6.0,<7.0.0",
+    "typing_extensions>=3.10.0"
 ]
 
 [tool.hatch.version]
@@ -118,6 +119,7 @@ path = "lilya/__init__.py"
 [tool.hatch.envs.default]
 dependencies = [
     "mypy==1.10.0",
+    "typing_extensions>=3.10.0",
     "ruff>=0.3.0,<5.0.0",
     "pre-commit>=3.3.1,<4.0.0",
     "devtools>=0.12.2",

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -283,7 +283,7 @@ def test_multipart_request_mixed_files_and_data(
     client = test_client_factory(app)
     response = client.post(
         "/",
-        data=(
+        content=(
             # data
             b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"  # type: ignore
             b'Content-Disposition: form-data; name="field0"\r\n\r\n'
@@ -321,7 +321,7 @@ def test_multipart_request_with_charset_for_filename(
     client = test_client_factory(app)
     response = client.post(
         "/",
-        data=(
+        content=(
             # file
             b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"  # type: ignore
             b'Content-Disposition: form-data; name="file"; filename="\xe6\x96\x87\xe6\x9b\xb8.txt"\r\n'  # noqa: E501
@@ -351,7 +351,7 @@ def test_multipart_request_without_charset_for_filename(
     client = test_client_factory(app)
     response = client.post(
         "/",
-        data=(
+        content=(
             # file
             b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"  # type: ignore
             b'Content-Disposition: form-data; name="file"; filename="\xe7\x94\xbb\xe5\x83\x8f.jpg"\r\n'  # noqa: E501
@@ -379,7 +379,7 @@ def test_multipart_request_with_encoded_value(
     client = test_client_factory(app)
     response = client.post(
         "/",
-        data=(
+        content=(
             b"--20b303e711c4ab8c443184ac833ab00f\r\n"  # type: ignore
             b"Content-Disposition: form-data; "
             b'name="value"\r\n\r\n'
@@ -463,7 +463,7 @@ def test_missing_boundary_parameter(
     with expectation:
         res = client.post(
             "/",
-            data=(
+            content=(
                 # file
                 b'Content-Disposition: form-data; name="file"; filename="\xe6\x96\x87\xe6\x9b\xb8.txt"\r\n'  # type: ignore # noqa: E501
                 b"Content-Type: text/plain\r\n\r\n"
@@ -491,7 +491,7 @@ def test_missing_name_parameter_on_content_disposition(
     with expectation:
         res = client.post(
             "/",
-            data=(
+            content=(
                 # data
                 b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"  # type: ignore
                 b'Content-Disposition: form-data; ="field0"\r\n\r\n'
@@ -525,7 +525,7 @@ def test_too_many_fields_raise(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -556,7 +556,7 @@ def test_too_many_files_raise(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -587,7 +587,7 @@ def test_too_many_files_single_field_raise(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -619,7 +619,7 @@ def test_too_many_files_and_fields_raise(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -649,7 +649,7 @@ def test_max_fields_is_customizable_low_raises(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -683,7 +683,7 @@ def test_max_files_is_customizable_low_raises(
     with expectation:
         res = client.post(
             "/",
-            data=data,  # type: ignore
+            content=data,  # type: ignore
             headers={"Content-Type": ("multipart/form-data; boundary=B")},
         )
         assert res.status_code == 400
@@ -706,7 +706,7 @@ def test_max_fields_is_customizable_high(
     data += b"--B--\r\n"
     res = client.post(
         "/",
-        data=data,  # type: ignore
+        content=data,  # type: ignore
         headers={"Content-Type": ("multipart/form-data; boundary=B")},
     )
     assert res.status_code == 200

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -139,7 +139,7 @@ def test_request_body(test_client_factory):
     response = client.post("/", json={"a": "123"})
     assert response.json() == {"body": '{"a": "123"}'}
 
-    response = client.post("/", data="abc")
+    response = client.post("/", content="abc")
     assert response.json() == {"body": "abc"}
 
 
@@ -160,7 +160,7 @@ def test_request_stream(test_client_factory):
     response = client.post("/", json={"a": "123"})
     assert response.json() == {"body": '{"a": "123"}'}
 
-    response = client.post("/", data="abc")
+    response = client.post("/", content="abc")
     assert response.json() == {"body": "abc"}
 
 
@@ -202,7 +202,7 @@ def test_request_body_then_stream(test_client_factory):
 
     client = test_client_factory(app)
 
-    response = client.post("/", data="abc")
+    response = client.post("/", content="abc")
     assert response.json() == {"body": "abc", "stream": "abc"}
 
 
@@ -221,7 +221,7 @@ def test_request_stream_then_body(test_client_factory):
 
     client = test_client_factory(app)
 
-    response = client.post("/", data="abc")
+    response = client.post("/", content="abc")
     assert response.json() == {"body": "<stream consumed>", "stream": "abc"}
 
 
@@ -495,7 +495,7 @@ def test_chunked_encoding(test_client_factory):
         yield b"foo"
         yield b"bar"
 
-    response = client.post("/", data=post_body())
+    response = client.post("/", content=post_body())
     assert response.json() == {"body": "foobar"}
 
 


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes
- typing_extensions errors on python >= 3.10
- Deprecation warnings
- Newer postgres docker image

In short a maintenance cleanup. 