### PR TITLE
fix named tuple encoder

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -7,11 +7,9 @@ hide:
 
 ## Unreleased
 
-
 ### Fixed
 
 - Crash when passing string to is_type_structure (e.g. string annotations).
-
 
 ## 0.11.1
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,14 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+
+### Fixed
+
+- Crash when passing string to is_type_structure (e.g. string annotations).
+
+
 ## 0.11.1
 
 ### Added

--- a/lilya/_internal/_encoders.py
+++ b/lilya/_internal/_encoders.py
@@ -79,7 +79,7 @@ class NamedTupleEncoder(EncoderProtocol, MoldingProtocol):
         return isinstance(value, tuple) and hasattr(value, "_asdict")
 
     def is_type_structure(self, value: Any) -> bool:
-        return issubclass(value, tuple) and hasattr(value, "_asdict")
+        return isclass(value) and issubclass(value, tuple) and hasattr(value, "_asdict")
 
     def serialize(self, obj: Any) -> dict:
         return cast(dict, obj._asdict())

--- a/tests/test_encoders_interface.py
+++ b/tests/test_encoders_interface.py
@@ -80,5 +80,5 @@ def test_idempotence(value, json_encode_kwargs):
     assert apply_structure(value_type, json_encode(value, **json_encode_kwargs)) == value
 
 
-def test_not_crash_on_strings():
+def test_dont_crash_on_strings():
     apply_structure("test", {})

--- a/tests/test_encoders_interface.py
+++ b/tests/test_encoders_interface.py
@@ -78,3 +78,7 @@ class FooSimple:
 def test_idempotence(value, json_encode_kwargs):
     value_type = type(value)
     assert apply_structure(value_type, json_encode(value, **json_encode_kwargs)) == value
+
+
+def test_not_crash_on_strings():
+    apply_structure("test", {})


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

NamedTupleEncoder crashes when strings are passed to the `is_type_structure` function.