### PR TITLE
 harden lilya against invalid encoders

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,13 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Fixed
+
+- Ensure encoders used for `apply_structure` have at least `encode` and `is_type_structure`.
+  The remaining methods are ensured by `EncodeProtocol` check.
+
 ## 0.11.2
 
 ### Changed

--- a/lilya/_internal/_encoders.py
+++ b/lilya/_internal/_encoders.py
@@ -307,8 +307,10 @@ def apply_structure(
         encoder_types = ENCODER_TYPES.get()
 
         for encoder in encoder_types:
-            if hasattr(encoder, "encode") and cast(MoldingProtocol, encoder).is_type_structure(
-                structure
+            if (
+                hasattr(encoder, "encode")
+                and hasattr(encoder, "is_type_structure")
+                and encoder.is_type_structure(structure)
             ):
                 if encoder.is_type(value):
                     return value


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [ ] I branched out from the latest main or is a sub-branch.

### Summary or description
Changes:
- harden lilya against invalid encoders for apply_structure.
