### PR TITLE
Provide multiple directories to StaticFiles with fallthrough behaviour

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -12,6 +12,10 @@ hide:
 - `RequestContextMiddleware` added allowing request objects being used without a context of a request
 without explicitly declaring it inside handlers.
 
+### Changed
+
+- Allow multiple directories in `StaticFiles`. This enables providing overwrites/defaults.
+
 ## 0.11.4
 
 ### Added 

--- a/docs/en/docs/static-files.md
+++ b/docs/en/docs/static-files.md
@@ -4,46 +4,38 @@ Lilya provides a convenient `StaticFiles` class for serving files from a specifi
 
 ## Parameters
 
-- `directory` - A string or [os.PathLike][pathlike] indicating the directory path.
+- `directory` - A string or [os.PathLike][pathlike] indicating the directory path. You can also provide a list or tuple for using multiple directories.
 - `packages` - A list of strings or list of tuples of strings representing Python packages.
 - `html` - Operate in HTML mode, automatically loading `index.html` for directories if it exists.
 - `check_dir` - Ensure that the directory exists upon instantiation. Defaults to `True`.
 - `follow_symlink` - A boolean indicating whether symbolic links for files and directories should be followed. Defaults to `False`.
 
 ```python
-from lilya.apps import Lilya
-from lilya.routing import Include
-from lilya.staticfiles import StaticFiles
-
-
-app = Lilya(routes=[
-    Include('/static', app=StaticFiles(directory='static'), name="static"),
-])
+    {!> ../../../docs_src/static_files/basic.py!}
 ```
 
 For requests that do not match, static files will respond with "404 Not Found" or "405 Method Not Allowed" responses.
 In HTML mode, if a `404.html` file exists, it will be displayed as the 404 response.
 
+As directory also a tuple or list can be provided. This is useful for overwrites or multiple directories which should served under the same
+location.
+You can theoretically also provide multiple `StaticFiles` but sacrifces the fallthrough behaviour this way.
+
+```python
+    {!> ../../../docs_src/static_files/basic_overwrite.py!}
+```
+
 The `packages` option allows inclusion of "static" directories from within a Python package.
 The Python "bootstrap4" package serves as an example.
 
 ```python
-from lilya.apps import Lilya
-from lilya.routing import Include
-from lilya.staticfiles import StaticFiles
-
-
-app = Lilya(routes=[
-    Include('/static', app=StaticFiles(directory='static', packages=['bootstrap4']), name="static"),
-])
+    {!> ../../../docs_src/static_files/packages.py!}
 ```
 
 By default, `StaticFiles` looks for the `statics` directory in each package. You can modify the default directory by specifying a tuple of strings.
 
 ```python
-routes=[
-    Include('/static', app=StaticFiles(packages=[('bootstrap4', 'static')]), name="static"),
-]
+    {!> ../../../docs_src/static_files/packages_custom.py!}
 ```
 
 While you may choose to include static files directly within the "static" directory, using Python packaging to include static files can be beneficial for bundling reusable components.

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -5,127 +5,127 @@ theme:
   name: material
   language: en
   palette:
-    - scheme: default
-      primary: light blue
-      accent: amber
-      media: "(prefers-color-scheme: light)"
-      toggle:
-        icon: material/lightbulb
-        name: Switch to dark mode
-    - scheme: slate
-      media: "(prefers-color-scheme: dark)"
-      primary: light blue
-      accent: amber
-      toggle:
-        icon: material/lightbulb-outline
-        name: Switch to light mode
+  - scheme: default
+    primary: light blue
+    accent: amber
+    media: '(prefers-color-scheme: light)'
+    toggle:
+      icon: material/lightbulb
+      name: Switch to dark mode
+  - scheme: slate
+    media: '(prefers-color-scheme: dark)'
+    primary: light blue
+    accent: amber
+    toggle:
+      icon: material/lightbulb-outline
+      name: Switch to light mode
   favicon: statics/images/favicon.ico
   logo: statics/images/white.png
   features:
-    - search.suggest
-    - search.highlight
-    - content.tabs.link
-    - content.code.copy
-    - content.code.annotate
-    - content.tooltips
-    - content.code.select
-    - navigation.indexes
-    - navigation.path
-    - navigation.tabs
+  - search.suggest
+  - search.highlight
+  - content.tabs.link
+  - content.code.copy
+  - content.code.annotate
+  - content.tooltips
+  - content.code.select
+  - navigation.indexes
+  - navigation.path
+  - navigation.tabs
 repo_name: dymmond/lilya
 repo_url: https://github.com/dymmond/lilya
-edit_uri: ""
+edit_uri: ''
 plugins:
-  - search
-  - meta-descriptions:
-      export_csv: false
-      quiet: false
-      enable_checks: false
-      min_length: 50
-      max_length: 160
-      trim: false
-  - mkdocstrings:
-      handlers:
-        python:
-          options:
-            extensions:
-              - griffe_typingdoc
-            show_root_heading: true
-            show_if_no_docstring: true
-            preload_modules:
-              - httpx
-              - a2wsgi
-            inherited_members: true
-            members_order: source
-            separate_signature: true
-            unwrap_annotated: true
-            filters:
-              - "!^_"
-            merge_init_into_class: true
-            docstring_section_style: spacy
-            signature_crossrefs: true
-            show_symbol_type_heading: true
-            show_symbol_type_toc: true
+- search
+- meta-descriptions:
+    export_csv: false
+    quiet: false
+    enable_checks: false
+    min_length: 50
+    max_length: 160
+    trim: false
+- mkdocstrings:
+    handlers:
+      python:
+        options:
+          extensions:
+          - griffe_typingdoc
+          show_root_heading: true
+          show_if_no_docstring: true
+          preload_modules:
+          - httpx
+          - a2wsgi
+          inherited_members: true
+          members_order: source
+          separate_signature: true
+          unwrap_annotated: true
+          filters:
+          - '!^_'
+          merge_init_into_class: true
+          docstring_section_style: spacy
+          signature_crossrefs: true
+          show_symbol_type_heading: true
+          show_symbol_type_toc: true
 nav:
-  - index.md
-  - Resources:
-      - resources/index.md
-      - applications.md
-      - settings.md
-      - routing.md
-      - controllers.md
-      - requests.md
-      - responses.md
-      - websockets.md
-      - encoders.md
-      - context.md
-      - authentication.md
-  - Features:
-      - features/index.md
-      - tasks.md
-      - lifespan.md
-      - middleware.md
-      - permissions.md
-      - static-files.md
-      - templates.md
-      - server-push.md
-      - exceptions.md
-      - wsgi.md
-      - environments.md
-  - Clients:
-      - clients/index.md
-      - Lilya Client:
-          - lilya-cli.md
-          - directives/discovery.md
-          - directives/directives.md
-          - directives/custom-directives.md
-          - directives/shell.md
-      - test-client.md
-  - Deployment:
-      - deployment/index.md
-      - intro.md
-      - docker.md
-  - contributing.md
-  - sponsorship.md
-  - release-notes.md
+- index.md
+- Resources:
+  - resources/index.md
+  - applications.md
+  - settings.md
+  - routing.md
+  - controllers.md
+  - requests.md
+  - responses.md
+  - websockets.md
+  - encoders.md
+  - context.md
+  - authentication.md
+- Features:
+  - features/index.md
+  - tasks.md
+  - lifespan.md
+  - middleware.md
+  - permissions.md
+  - static-files.md
+  - templates.md
+  - server-push.md
+  - exceptions.md
+  - wsgi.md
+  - environments.md
+- Clients:
+  - clients/index.md
+  - Lilya Client:
+    - lilya-cli.md
+    - directives/discovery.md
+    - directives/directives.md
+    - directives/custom-directives.md
+    - directives/shell.md
+  - test-client.md
+- Deployment:
+  - deployment/index.md
+  - intro.md
+  - docker.md
+- contributing.md
+- sponsorship.md
+- release-notes.md
 markdown_extensions:
-  - toc:
-      permalink: true
-  - mdx_include:
-      base_path: docs
-  - admonition
-  - extra
-  - pymdownx.superfences
-  - pymdownx.tabbed:
-      alternate_style: true
-  - pymdownx.highlight
-  - attr_list
-  - md_in_html
+- toc:
+    permalink: true
+- mdx_include:
+    base_path: docs
+- admonition
+- extra
+- pymdownx.superfences
+- pymdownx.tabbed:
+    alternate_style: true
+- pymdownx.highlight
+- attr_list
+- md_in_html
 extra:
   alternate:
-    - link: /
-      name: en - English
-    - link: /pt/
-      name: pt - português
+  - link: /
+    name: en - English
+  - link: /pt/
+    name: pt - português
 hooks:
-  - ../../scripts/hooks.py
+- ../../scripts/hooks.py

--- a/docs/pt/docs/responses.md
+++ b/docs/pt/docs/responses.md
@@ -340,7 +340,7 @@ from lilya.encoders import Encoder, register_encoder
 Criar e registrar um codificador que lida com tipos `msgspec.Struct`.
 
 ```python
-{!> ../../../docs_src/encoders/example.py !}
+{!> ../../../docs_src/encoders/msgspec.py !}
 ```
 
 Simples, certo? Porque agora o `MsgSpecEncoder` está registrado, pode simplesmente fazer isto nos handlers
@@ -385,7 +385,7 @@ Vejamos como seria para cada um deles.
 **Para msgspec Struct**
 
 ```python
-{!> ../../../docs_src/encoders/example.py !}
+{!> ../../../docs_src/encoders/msgspec.py !}
 ```
 
 **Para attrs**

--- a/docs_src/static_files/basic.py
+++ b/docs_src/static_files/basic.py
@@ -1,0 +1,8 @@
+from lilya.apps import Lilya
+from lilya.routing import Include
+from lilya.staticfiles import StaticFiles
+
+
+app = Lilya(routes=[
+    Include('/static', app=StaticFiles(directory='static'), name="static"),
+])

--- a/docs_src/static_files/basic_overwrite.py
+++ b/docs_src/static_files/basic_overwrite.py
@@ -1,0 +1,8 @@
+from lilya.apps import Lilya
+from lilya.routing import Include
+from lilya.staticfiles import StaticFiles
+
+
+app = Lilya(routes=[
+    Include('/static', app=StaticFiles(directory=['static/overwrites', 'static', 'static/fallback']), name="static"),
+])

--- a/docs_src/static_files/packages.py
+++ b/docs_src/static_files/packages.py
@@ -1,0 +1,8 @@
+from lilya.apps import Lilya
+from lilya.routing import Include
+from lilya.staticfiles import StaticFiles
+
+
+app = Lilya(routes=[
+    Include('/static', app=StaticFiles(directory='static', packages=['bootstrap4']), name="static"),
+])

--- a/docs_src/static_files/packages_custom.py
+++ b/docs_src/static_files/packages_custom.py
@@ -1,0 +1,8 @@
+from lilya.apps import Lilya
+from lilya.routing import Include
+from lilya.staticfiles import StaticFiles
+
+
+app = Lilya(routes=[
+    Include('/static', app=StaticFiles(directory='static', packages=[('bootstrap4', 'static')]), name="static"),
+])

--- a/lilya/staticfiles.py
+++ b/lilya/staticfiles.py
@@ -41,7 +41,7 @@ class StaticFiles:
     def __init__(
         self,
         *,
-        directory: PathLike | list[PathLike] | tuple[PathLike] | None = None,
+        directory: PathLike | list[PathLike] | tuple[PathLike, ...] | None = None,
         packages: list[str | tuple[str, str]] | None = None,
         html: bool = False,
         check_dir: bool = True,
@@ -51,7 +51,7 @@ class StaticFiles:
         Initialize StaticFiles middleware.
 
         Args:
-            directory (PathLike | List[PathLike] | Tuple[PathLike] | None): Base directory for serving static files.
+            directory (PathLike | List[PathLike] | Tuple[PathLike, ...] | None): Base directory for serving static files.
             packages (List[str | Tuple[str, str]] | None): List of packages containing static files.
             html (bool): Flag to enable HTML file handling for directories.
             check_dir (bool): Flag to check if the directory exists.
@@ -75,7 +75,7 @@ class StaticFiles:
 
     def get_directories(
         self,
-        directory: PathLike | list[PathLike] | tuple[PathLike] | None = None,
+        directory: PathLike | list[PathLike] | tuple[PathLike, ...] | None = None,
         packages: list[str | tuple[str, str]] | None = None,
     ) -> list[PathLike]:
         """

--- a/lilya/staticfiles.py
+++ b/lilya/staticfiles.py
@@ -41,7 +41,7 @@ class StaticFiles:
     def __init__(
         self,
         *,
-        directory: str | None = None,
+        directory: PathLike | list[PathLike] | tuple[PathLike] | None = None,
         packages: list[str | tuple[str, str]] | None = None,
         html: bool = False,
         check_dir: bool = True,
@@ -51,26 +51,33 @@ class StaticFiles:
         Initialize StaticFiles middleware.
 
         Args:
-            directory (str | None): Base directory for serving static files.
+            directory (PathLike | List[PathLike] | Tuple[PathLike] | None): Base directory for serving static files.
             packages (List[str | Tuple[str, str]] | None): List of packages containing static files.
             html (bool): Flag to enable HTML file handling for directories.
             check_dir (bool): Flag to check if the directory exists.
             follow_symlink (bool): Flag to follow symlinks.
         """
+
+        if directory:
+            directory = directory if isinstance(directory, (list, tuple)) else [directory]
+        else:
+            directory = None
         self.directory = directory
         self.packages = packages
         self.all_directories = self.get_directories(directory, packages)
         self.html = html
         self.config_checked = False
         self.follow_symlink = follow_symlink
-        if check_dir and directory is not None and not os.path.isdir(directory):
-            raise RuntimeError(f"Directory '{directory}' does not exist")
+        if check_dir and directory is not None:
+            for _dir in directory:
+                if not os.path.isdir(_dir):
+                    raise RuntimeError(f"Directory '{_dir}' does not exist")
 
     def get_directories(
         self,
-        directory: str | None = None,
+        directory: PathLike | list[PathLike] | tuple[PathLike] | None = None,
         packages: list[str | tuple[str, str]] | None = None,
-    ) -> list[str]:
+    ) -> list[PathLike]:
         """
         Given `directory` and `packages` arguments, return a list of all the
         directories that should be used for serving static files from.
@@ -82,9 +89,9 @@ class StaticFiles:
         Returns:
             List[str]: List of directories.
         """
-        directories = []
-        if directory is not None:
-            directories.append(directory)
+        directories: list[PathLike] = []
+        if directory:
+            directories.extend(directory if isinstance(directory, (list, tuple)) else [directory])
 
         for package in packages or []:
             if isinstance(package, tuple):
@@ -198,14 +205,13 @@ class StaticFiles:
             Tuple[str, os.stat_result | None]: Full path and stat result (or None if not found).
         """
         for directory in self.all_directories:
-            joined_path = os.path.join(directory, path)
-            full_path = self.get_full_path(directory, joined_path)
+            full_path = self.get_full_path(directory, path)
             stat_result = self.get_stat_result(full_path)
             if stat_result:
                 return full_path, stat_result
         return "", None
 
-    def get_full_path(self, directory: str, path: str) -> str:
+    def get_full_path(self, directory: PathLike, path: str) -> str:
         """
         Get the full path by joining the directory and path.
 
@@ -216,6 +222,7 @@ class StaticFiles:
         Returns:
             str: Full path.
         """
+        path = os.path.join(directory, path)
         if self.follow_symlink:
             return os.path.abspath(path)
         return os.path.realpath(path)
@@ -264,6 +271,18 @@ class StaticFiles:
             return StaticResponse(response.headers)
         return response
 
+    def _check_dirs(self) -> None:
+        assert self.directory is not None
+        for directory in self.directory:
+            try:
+                stat_result = os.stat(directory)
+            except FileNotFoundError:
+                raise RuntimeError(
+                    f"StaticFiles directory '{directory}' does not exist."
+                ) from None
+            if not (stat.S_ISDIR(stat_result.st_mode) or stat.S_ISLNK(stat_result.st_mode)):
+                raise RuntimeError(f"StaticFiles path '{directory}' is not a directory.")
+
     async def check_config(self) -> None:
         """
         Perform a one-off configuration check that StaticFiles is actually
@@ -272,15 +291,7 @@ class StaticFiles:
         """
         if self.directory is None:
             return
-
-        try:
-            stat_result = await anyio.to_thread.run_sync(os.stat, self.directory)
-        except FileNotFoundError:
-            raise RuntimeError(
-                f"StaticFiles directory '{self.directory}' does not exist."
-            ) from None
-        if not (stat.S_ISDIR(stat_result.st_mode) or stat.S_ISLNK(stat_result.st_mode)):
-            raise RuntimeError(f"StaticFiles path '{self.directory}' is not a directory.")
+        await anyio.to_thread.run_sync(self._check_dirs)
 
     def is_not_modified(self, response_headers: Header, request_headers: Header) -> bool:
         """

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -18,24 +18,30 @@ from lilya.routing import Include
 from lilya.staticfiles import StaticFiles
 
 
-def test_staticfiles(tmpdir, test_client_factory):
+@pytest.mark.parametrize(
+    "wrapper", [lambda x: x, lambda x: [x], lambda x: (x,)], ids=["direct", "list", "tuple"]
+)
+def test_staticfiles(tmpdir, test_client_factory, wrapper):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
         file.write("<file content>")
 
-    app = StaticFiles(directory=tmpdir)
+    app = StaticFiles(directory=wrapper(tmpdir))
     client = test_client_factory(app)
     response = client.get("/example.txt")
     assert response.status_code == 200
     assert response.text == "<file content>"
 
 
-def test_staticfiles_with_pathlib(tmp_path: Path, test_client_factory):
+@pytest.mark.parametrize(
+    "wrapper", [lambda x: x, lambda x: [x], lambda x: (x,)], ids=["direct", "list", "tuple"]
+)
+def test_staticfiles_with_pathlib(tmp_path: Path, test_client_factory, wrapper):
     path = tmp_path / "example.txt"
     with open(path, "w") as file:
         file.write("<file content>")
 
-    app = StaticFiles(directory=tmp_path)
+    app = StaticFiles(directory=wrapper(tmp_path))
     client = test_client_factory(app)
     response = client.get("/example.txt")
     assert response.status_code == 200


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:
- allow to provide multiple directories for static files
- Update docs
- Fix missing reference


# Why

Despite it is possible to provide multiple `StaticFiles` handlers, there is an issue:

it is not possible to fallthrough to the next directory. So you cannot provide overwrites or defaults.

This PR fixes this while fixing some missing references in docs and moving the examples in static_files.md to docs_src