### PR TITLE
fix serialization of primitives in Response

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -19,7 +19,7 @@ hide:
 
 ### Fixed
 
-- Fix serialization of primitives in the Response. Strip " by default.
+- Fix serialization of primitives in the Response. Strip `"` by default.
 
 ## 0.11.8
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -15,6 +15,12 @@ hide:
 
 - Refactor `SessionMiddleware`.
 
+## 0.11.9
+
+### Fixed
+
+- Fix serialization of primitives in the Response. Strip " by default.
+
 ## 0.11.8
 
 ### Fixed

--- a/lilya/responses.py
+++ b/lilya/responses.py
@@ -103,8 +103,7 @@ class Response:
         """
         Makes the Response object type.
         """
-        # only handle empty string not empty bytes. Bytes are handled later
-        if content is None or content is NoReturn or content == "":
+        if content is None or content is NoReturn:
             return b""
         if isinstance(content, (bytes, memoryview)):
             return content


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Before:

When passing e.g. an int or float as a content in make_response and using a normal Response a crash was the result.

After:

Handle everything gracefully.

This bug is old but was only exposed by a new test.