### PR TITLE
middleware fixes (warnings) & python 3.13

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     services:
       postgres:

--- a/lilya/middleware/server_error.py
+++ b/lilya/middleware/server_error.py
@@ -198,7 +198,7 @@ class ServerErrorMiddleware(MiddlewareProtocol):
         try:
             exc_type_str = traceback_obj.exc_type_str
         except Exception:
-            # for older python versions
+            # for older python versions < 3.13
             exc_type_str = traceback_obj.exc_type.__name__
         error = f"{html.escape(exc_type_str)}: " f"{html.escape(str(traceback_obj))}"
 

--- a/lilya/middleware/server_error.py
+++ b/lilya/middleware/server_error.py
@@ -195,10 +195,12 @@ class ServerErrorMiddleware(MiddlewareProtocol):
                 is_collapsed = True
 
         # escape error class and text
-        error = (
-            f"{html.escape(traceback_obj.exc_type.__name__)}: "
-            f"{html.escape(str(traceback_obj))}"
-        )
+        try:
+            exc_type_str = traceback_obj.exc_type_str
+        except Exception:
+            # for older python versions
+            exc_type_str = traceback_obj.exc_type.__name__
+        error = f"{html.escape(exc_type_str)}: " f"{html.escape(str(traceback_obj))}"
 
         template = get_template_errors()
         return template.format(styles=get_css_style(), js=get_js(), error=error, exc_html=exc_html)


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:

- server_error: Use non-deprecated exc_type_str instead of `traceback_obj.exc_type.__name__`. Deprecation in python 3.13.
- compression: Initialize gzip file only when required and close properly
- add python 3.13 to test matrix
