### PR TITLE
allow async response content & enable async jinja templates

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,14 @@ hide:
 
 # Release Notes
 
+
+## 0.12.4
+
+### Added
+
+- Compatibility mode for async response content.
+- Support for jinja enable_async option.
+
 ## 0.12.3
 
 ### Fixed

--- a/docs/en/docs/responses.md
+++ b/docs/en/docs/responses.md
@@ -267,6 +267,15 @@ can later be used to serialise your response automatically and then passed to th
 Check the [build a custom encoder](#build-a-custom-encoder) and [custom encoders with make_response](#custom-encoders-and-the-make_response)
 for more details and how to leverage the power of Lilya.
 
+## Async content
+
+You can pass coroutines as content to most standard responses. This will delay the evaluation of the content to the `__call__` method
+if `resolve_async_content()` is not called earlier.
+The cool part, we reuse the main eventloop.
+
+Note, this means we get the body attribute of the response as well as the `content-length` header later
+after the `resolve_async_content()` call (which is called in `__call__`).
+
 ## Delegate to Lilya
 
 Delegating to Lilya means that if no response is specified, Lilya will go through the internal

--- a/docs/en/docs/templates.md
+++ b/docs/en/docs/templates.md
@@ -39,6 +39,21 @@ The get_template_response function expects the following arguments:
 
 
 Any additional arguments or keyword arguments provided will be passed directly to `TemplateResponse`.
+This is for example handy when you need async templates.
+
+### Async templates
+
+One cool feature of jinja2 is, that you can you can have async templates. This means awaitables are automatically resolved
+and async iteration is supported out of the box.
+This is especcially useful for the edgy/saffier orms.
+
+```python
+{!> ../../../docs_src/templates/template_async.py !}
+```
+
+And now you can iterate over QuerySets out of the box. Nothing else is required.
+Note, internally the template response switches the render method and uses the [async content](./responses.md#async-content) feature
+so you can only access the body attribute after calling `__call__` or `resolve_async_content()`.
 
 ### Optional Arguments
 

--- a/docs_src/templates/template_async.py
+++ b/docs_src/templates/template_async.py
@@ -1,0 +1,20 @@
+from lilya.apps import Lilya
+from lilya.requests import Request
+from lilya.routing import Include, Path
+from lilya.staticfiles import StaticFiles
+from lilya.templating import Jinja2Template
+
+templates = Jinja2Template(directory="templates", enable_async=True)
+
+
+async def homepage(request: Request):
+    return templates.get_template_response(request, "index.html")
+
+
+app = Lilya(
+    debug=True,
+    routes=[
+        Path("/", homepage),
+        Include("/static", StaticFiles(directory="static"), name="static"),
+    ],
+)

--- a/lilya/templating/base.py
+++ b/lilya/templating/base.py
@@ -21,8 +21,9 @@ PathLike = Union[str, "os.PathLike[str]"]
 
 
 class BaseTemplateRenderer(Generic[T]):
-    def __init__(self, template: T) -> None:
+    def __init__(self, template: T, render_function_name: str = "render") -> None:
         self.template = template
+        self.render_function_name = render_function_name
 
     def get_template(self, name: str) -> T:
         return self.template.get_template(name=name)  # type: ignore
@@ -49,4 +50,5 @@ class BaseTemplateRenderer(Generic[T]):
             headers=headers,
             media_type=media_type,
             background=background,
+            render_function_name=self.render_function_name,
         )

--- a/lilya/templating/jinja.py
+++ b/lilya/templating/jinja.py
@@ -110,9 +110,9 @@ class TemplateRenderer(BaseTemplateRenderer):
             AssertionError: If the 'request' instance is not present or is invalid.
         """
         request = args[0] if len(args) > 0 else kwargs.get("request")
-        assert isinstance(request, Request), (
-            "The first argument should always be a 'Request' instance."
-        )
+        assert isinstance(
+            request, Request
+        ), "The first argument should always be a 'Request' instance."
         return request
 
 
@@ -137,9 +137,9 @@ class Jinja2Template:
             **options (Any): Additional options to configure the Jinja2 environment.
         """
         self.context_processors: Any = options.pop("context_processors", {})
-        assert env or directory, (
-            "either 'env' or 'directory' arguments must be passed but not both."
-        )
+        assert (
+            env or directory
+        ), "either 'env' or 'directory' arguments must be passed but not both."
 
         if env is None:
             self.env = self._create_environment(directory, **options)

--- a/lilya/templating/jinja.py
+++ b/lilya/templating/jinja.py
@@ -110,9 +110,9 @@ class TemplateRenderer(BaseTemplateRenderer):
             AssertionError: If the 'request' instance is not present or is invalid.
         """
         request = args[0] if len(args) > 0 else kwargs.get("request")
-        assert isinstance(
-            request, Request
-        ), "The first argument should always be a 'Request' instance."
+        assert isinstance(request, Request), (
+            "The first argument should always be a 'Request' instance."
+        )
         return request
 
 
@@ -137,9 +137,9 @@ class Jinja2Template:
             **options (Any): Additional options to configure the Jinja2 environment.
         """
         self.context_processors: Any = options.pop("context_processors", {})
-        assert (
-            env or directory
-        ), "either 'env' or 'directory' arguments must be passed but not both."
+        assert env or directory, (
+            "either 'env' or 'directory' arguments must be passed but not both."
+        )
 
         if env is None:
             self.env = self._create_environment(directory, **options)
@@ -234,5 +234,7 @@ class Jinja2Template:
         Returns:
             TemplateResponse: The rendered template response.
         """
-        template_renderer = TemplateRenderer(template=self)
+        template_renderer = TemplateRenderer(
+            template=self, render_function_name="render_async" if self.env.is_async else "render"
+        )
         return template_renderer(*args, **kwargs)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -53,6 +53,20 @@ def test_text_response(test_client_factory):
     assert response.text == "hello, world"
 
 
+def test_async_text_response(test_client_factory):
+    async def create_hello_world():
+        return "hello, world"
+
+    async def app(scope, receive, send):
+        response = Response(create_hello_world(), media_type="text/plain", encoders=[FooEncoder])
+        assert isinstance(response.encoders[0], FooEncoder)
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.text == "hello, world"
+
+
 def test_ok_response(test_client_factory):
     async def app(scope, receive, send):
         response = Ok("hello, world", encoders=[FooEncoder])


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:

- allow async response content
- add support for jinja enable_async