### PR TITLE
add offloading for FileResponse

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,12 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Changed
+
+- FileResponse tries to offload the file response to the server in case it supports the extensions.
+
 ## 0.12.11
 
 ### Added

--- a/lilya/responses.py
+++ b/lilya/responses.py
@@ -513,9 +513,27 @@ class FileResponse(Response):
 
         prefix = "websocket." if scope["type"] == "websocket" else ""
         await send(self.message(prefix=prefix))
+        extensions = scope.get("extensions", {})
 
         if self.send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
+        elif "http.response.pathsend" in extensions:
+            await send({"type": "http.response.pathsend", "path": self.path})
+        elif "http.response.zerocopysend" in extensions:
+            async with await anyio.open_file(self.path, mode="rb") as file:
+                size = int(self.headers["content-length"])
+                more_body = True
+                while more_body:
+                    more_body = size > self.chunk_size
+                    await send(
+                        {
+                            "type": "http.response.zerocopysend",
+                            "file": file.fileno(),
+                            "count": self.chunk_size,
+                            "more_body": more_body,
+                        }
+                    )
+                    size -= self.chunk_size
         else:
             async with await anyio.open_file(self.path, mode="rb") as file:
                 more_body = True

--- a/lilya/responses.py
+++ b/lilya/responses.py
@@ -528,7 +528,7 @@ class FileResponse(Response):
                     await send(
                         {
                             "type": "http.response.zerocopysend",
-                            "file": file.fileno(),
+                            "file": file.fileno(),  # type: ignore
                             "count": self.chunk_size,
                             "more_body": more_body,
                         }

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -309,25 +309,25 @@ def test_file_response(tmpdir, test_client_factory):
     assert filled_by_bg_task == "6, 7, 8, 9"
 
 
-@pytest.mark.parametrize("extensions,result", [
-    ({"http.response.pathsend": {}}, "http.response.pathsend"),
-    ({"http.response.zerocopysend": {}}, "http.response.zerocopysend"),
-])
+@pytest.mark.parametrize(
+    "extensions,result",
+    [
+        ({"http.response.pathsend": {}}, "http.response.pathsend"),
+        ({"http.response.zerocopysend": {}}, "http.response.zerocopysend"),
+    ],
+)
 async def test_file_response_optimizations(tmpdir, test_client_factory, extensions, result):
     path = os.path.join(tmpdir, "xyz")
     content = b"<file content>" * 1000
     with open(path, "wb") as file:
         file.write(content)
 
-    fresponse = FileResponse(
-        path=path, filename="example.png"
-    )
+    fresponse = FileResponse(path=path, filename="example.png")
     fresponse.chunk_size = 10
     responses = Queue()
     await fresponse({"extensions": extensions, "type": "response"}, None, responses.put)
     response1 = await responses.get()
     response2 = await responses.get()
-
 
     expected_disposition = 'attachment; filename="example.png"'
     assert response1["headers"]["content-type"] == "image/png"
@@ -342,6 +342,7 @@ async def test_file_response_optimizations(tmpdir, test_client_factory, extensio
         while response2["more_body"]:
             response2 = await responses.get()
         assert not response2["more_body"]
+
 
 def test_file_response_with_directory_raises_error(tmpdir, test_client_factory):
     app = FileResponse(path=tmpdir, filename="example.png")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -2,6 +2,7 @@ import datetime as dt
 import os
 import time
 import typing
+from asyncio import Queue
 from http.cookies import SimpleCookie
 
 import anyio
@@ -307,6 +308,40 @@ def test_file_response(tmpdir, test_client_factory):
     assert "etag" in response.headers
     assert filled_by_bg_task == "6, 7, 8, 9"
 
+
+@pytest.mark.parametrize("extensions,result", [
+    ({"http.response.pathsend": {}}, "http.response.pathsend"),
+    ({"http.response.zerocopysend": {}}, "http.response.zerocopysend"),
+])
+async def test_file_response_optimizations(tmpdir, test_client_factory, extensions, result):
+    path = os.path.join(tmpdir, "xyz")
+    content = b"<file content>" * 1000
+    with open(path, "wb") as file:
+        file.write(content)
+
+    fresponse = FileResponse(
+        path=path, filename="example.png"
+    )
+    fresponse.chunk_size = 10
+    responses = Queue()
+    await fresponse({"extensions": extensions, "type": "response"}, None, responses.put)
+    response1 = await responses.get()
+    response2 = await responses.get()
+
+
+    expected_disposition = 'attachment; filename="example.png"'
+    assert response1["headers"]["content-type"] == "image/png"
+    assert response1["headers"]["content-disposition"] == expected_disposition
+    assert response2["type"] == result
+    if result == "http.response.pathsend":
+        assert response2["path"] == path
+    else:
+        assert response2["count"] == fresponse.chunk_size
+        assert response2["file"] > 0
+        assert response2["more_body"]
+        while response2["more_body"]:
+            response2 = await responses.get()
+        assert not response2["more_body"]
 
 def test_file_response_with_directory_raises_error(tmpdir, test_client_factory):
     app = FileResponse(path=tmpdir, filename="example.png")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import os
+import sys
 import time
 import typing
 from asyncio import Queue
@@ -308,7 +309,6 @@ def test_file_response(tmpdir, test_client_factory):
     assert "etag" in response.headers
     assert filled_by_bg_task == "6, 7, 8, 9"
 
-
 @pytest.mark.parametrize(
     "extensions,result",
     [
@@ -316,7 +316,9 @@ def test_file_response(tmpdir, test_client_factory):
         ({"http.response.zerocopysend": {}}, "http.response.zerocopysend"),
     ],
 )
-async def test_file_response_optimizations(tmpdir, test_client_factory, extensions, result):
+async def test_file_response_optimizations(tmpdir, extensions, result, anyio_backend):
+    if sys.version_info < (3, 10) and anyio_backend == "trio":
+        pytest.skip("Not supported combination of trio, python  < 3.10 and asyncio.Queue")
     path = os.path.join(tmpdir, "xyz")
     content = b"<file content>" * 1000
     with open(path, "wb") as file:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -309,6 +309,7 @@ def test_file_response(tmpdir, test_client_factory):
     assert "etag" in response.headers
     assert filled_by_bg_task == "6, 7, 8, 9"
 
+
 @pytest.mark.parametrize(
     "extensions,result",
     [


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Add implementation for file offloading.

Note: there is currently no server implementing it, so I test manually against the specs
