### PR TITLE
Update cache decorator

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -11,6 +11,10 @@ hide:
 
 - Support for automatic cast call for a function is a function is provided to cast in the `loader` of the [Environment](./environments.md).
 
+### Fixed
+
+- Fixed `@cache` when decorating Class controllers and function controllers.
+
 ## 0.19.3
 
 - Permission call order was reversed when called from within an Include, Path, Websocket and internal routing.

--- a/lilya/caches/memory.py
+++ b/lilya/caches/memory.py
@@ -5,6 +5,7 @@ import logging
 import time
 from typing import Any
 
+from lilya._internal._encoders import json_encode
 from lilya.protocols.cache import CacheBackend
 
 logger = logging.getLogger(__name__)
@@ -112,7 +113,7 @@ class InMemoryCache(CacheBackend):
         """
         try:
             expiry = time.time() + ttl if ttl else None
-            self._store[key] = (json.dumps(value).encode("utf-8"), expiry)
+            self._store[key] = (json.dumps(json_encode(value)).encode("utf-8"), expiry)
         except Exception as e:
             logger.exception(f"Cache set error: {e}")
 

--- a/lilya/caches/redis.py
+++ b/lilya/caches/redis.py
@@ -7,6 +7,7 @@ from typing import Any
 import anyio
 import anyio.from_thread
 
+from lilya._internal._encoders import json_encode
 from lilya.protocols.cache import CacheBackend
 
 try:
@@ -100,7 +101,7 @@ class RedisCache(CacheBackend):
             value (Any): The value to be cached.
             ttl (int | None, optional): Time-to-live in seconds. If `None`, the value never expires.
         """
-        data: bytes = json.dumps(value).encode("utf-8")
+        data: bytes = json.dumps(json_encode(value)).encode("utf-8")
         if ttl:
             await self.async_client.setex(key, ttl, data)
         else:

--- a/tests/caches/test_cache_with_handlers.py
+++ b/tests/caches/test_cache_with_handlers.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+
+from lilya.controllers import Controller
+from lilya.decorators import cache
+from lilya.routing import Path
+from lilya.testclient import create_client
+from tests.encoders.settings import EncoderSettings
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+def test_basic_caching_memory(memory_cache, test_client_factory) -> None:
+    @cache(backend=memory_cache)
+    async def items_view(data: Item) -> Item:
+        return data
+
+    with create_client(
+        routes=[Path("/items", handler=items_view, methods=["POST"])],
+        settings_module=EncoderSettings,
+    ) as client:
+        response = client.post("/items", json={"id": 1, "name": "Test Item"})
+        assert response.status_code == 200
+        assert response.json() == {"id": 1, "name": "Test Item"}
+
+
+def test_controller_caching(memory_cache, test_client_factory) -> None:
+    class ItemsController(Controller):
+        @cache(backend=memory_cache)
+        async def post(self, data: Item) -> Item:
+            return data
+
+    with create_client(
+        routes=[Path("/items", handler=ItemsController)], settings_module=EncoderSettings
+    ) as client:
+        response = client.post("/items", json={"id": 1, "name": "Test Item"})
+        assert response.status_code == 200
+        assert response.json() == {"id": 1, "name": "Test Item"}


### PR DESCRIPTION
The `@cache` decorator was raising a 500 when decorating handlers and controllers. This addresses the serialization issue.