### PR TITLE
fix crash in runserver when no autodiscovery, optimize code

### DIFF
--- a/lilya/cli/directives/operations/runserver.py
+++ b/lilya/cli/directives/operations/runserver.py
@@ -139,21 +139,20 @@ def runserver(
         toolkit.print(f"Importing module '{env.path}'", tag="Lilya")
         toolkit.print_line()
 
-        root_tree = get_app_tree(
-            env.module_info.module_paths, discovery_file=env.module_info.discovery_file
-        )
-
-        toolkit.print(root_tree, tag="module")
-        toolkit.print_line()
-
-        toolkit.print(
-            "The [bold]Lilya[/bold] object is imported using the following code:",
-            tag="code",
-        )
-        toolkit.print(
-            f"[underline]from [bold]{env.module_info.module_import[0]}[/bold] import [bold]{env.module_info.module_import[1]}[/bold]",
-            tag=env.module_info.module_import[1],
-        )
+        if env.module_info.module_paths:
+            root_tree = get_app_tree(
+                env.module_info.module_paths, discovery_file=env.module_info.discovery_file
+            )
+            toolkit.print(root_tree, tag="module")
+            toolkit.print_line()
+            toolkit.print(
+                "The [bold]Lilya[/bold] object is imported using the following code:",
+                tag="code",
+            )
+            toolkit.print(
+                f"[underline]from [bold]{env.module_info.module_import[0]}[/bold] import [bold]{env.module_info.module_import[1]}[/bold]",
+                tag=env.module_info.module_import[1],
+            )
 
         url = f"http://{host}:{port}"
         docs = f"http://{host}:{port}/docs/swagger"

--- a/lilya/cli/env.py
+++ b/lilya/cli/env.py
@@ -189,9 +189,8 @@ class DirectiveEnv:
             folder_path = cwd / folder
             scaffold = self._find_app_in_folder(folder_path, cwd)
 
-            if not scaffold:
-                continue
-            break
+            if scaffold:
+                break
 
         if not scaffold:
             raise EnvError("Could not find a Lilya application.")


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [ ] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:
- runserver crashes when env.module_info.module_paths is empty (--app in the cwd), bail out as the info is not so important.