### PR TITLE
fix: isolate ASGI scopes across middleware stacks

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -6,6 +6,10 @@
 
 - Property `scheduler` to AsynczConfig for easy access.
 
+### Fixed
+
+- Isolated ASGI scopes across Lilya middleware, permission, include, route, host, and websocket stack boundaries so nested apps with their own middleware, including `SessionMiddleware`, keep local precedence without leaking `scope` mutations upstream.
+
 ## 0.27.0
 
 ### Added

--- a/lilya/_internal/_middleware.py
+++ b/lilya/_internal/_middleware.py
@@ -61,12 +61,29 @@ class ScopeIsolationMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
+    def sync_route_metadata(self, source_scope: Scope, target_scope: Scope) -> None:
+        """
+        Copy Lilya-owned route metadata from the child scope into its parent scope.
+
+        These keys are intentionally whitelisted: response-side middleware and error
+        instrumentation need route metadata, but generic child scope mutations must remain
+        isolated from upstream middleware.
+        """
+        for key in ROUTE_SCOPE_KEYS:
+            if key in source_scope:
+                target_scope[key] = source_scope[key]
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         child_scope = copy_scope_for_middleware(scope)
-        await self.app(child_scope, receive, send)
-        for key in ROUTE_SCOPE_KEYS:
-            if key in child_scope:
-                scope[key] = child_scope[key]
+
+        async def send_with_route_metadata(message: Any) -> None:
+            self.sync_route_metadata(child_scope, scope)
+            await send(message)
+
+        try:
+            await self.app(child_scope, receive, send_with_route_metadata)
+        finally:
+            self.sync_route_metadata(child_scope, scope)
 
 
 def apply_asgi_stack(app: ASGIApp, stack: Sequence[Any] | None) -> ASGIApp:
@@ -87,5 +104,5 @@ def apply_asgi_stack(app: ASGIApp, stack: Sequence[Any] | None) -> ASGIApp:
 
     for cls, args, options in reversed(stack):
         child_app = app if hasattr(app, "__is_controller__") else ScopeIsolationMiddleware(app)
-        app = ScopeIsolationMiddleware(cls(app=child_app, *args, **options))
+        app = ScopeIsolationMiddleware(cls(child_app, *args, **options))
     return app

--- a/lilya/_internal/_middleware.py
+++ b/lilya/_internal/_middleware.py
@@ -75,9 +75,13 @@ class ScopeIsolationMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         child_scope = copy_scope_for_middleware(scope)
+        route_metadata_synced = False
 
         async def send_with_route_metadata(message: Any) -> None:
-            self.sync_route_metadata(child_scope, scope)
+            nonlocal route_metadata_synced
+            if not route_metadata_synced:
+                self.sync_route_metadata(child_scope, scope)
+                route_metadata_synced = True
             await send(message)
 
         try:

--- a/lilya/_internal/_middleware.py
+++ b/lilya/_internal/_middleware.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 from typing import Any, cast
 
 from lilya.middleware.base import DefineMiddleware
+from lilya.types import ASGIApp, Receive, Scope, Send
+
+ROUTE_SCOPE_KEYS = ("route", "route_path_template", "handler")
 
 
 @lru_cache(maxsize=1024)
@@ -22,3 +26,66 @@ def wrap_middleware(
     if isinstance(middleware, DefineMiddleware):
         return middleware
     return DefineMiddleware(cast(Any, middleware))
+
+
+def copy_scope_for_middleware(scope: Scope) -> Scope:
+    """
+    Return a scope copy suitable for handing to an ASGI middleware or child app.
+
+    The ASGI specification recommends copying the connection scope before mutating it and
+    passing it downstream, because otherwise values written by one middleware can leak back
+    upstream or across mounted applications. Lilya also detaches the mutable request header
+    container/list so middleware that rewrites request headers cannot mutate an upstream
+    observer's scope by sharing the same nested header object.
+    """
+    copied_scope = dict(scope)
+    if "headers" in copied_scope:
+        headers = copied_scope["headers"]
+        if hasattr(headers, "encoded_multi_items"):
+            copied_scope["headers"] = list(headers.encoded_multi_items())
+        else:
+            copied_scope["headers"] = list(headers)
+    return copied_scope
+
+
+class ScopeIsolationMiddleware:
+    """
+    ASGI boundary that gives the wrapped application its own mutable scope copy.
+
+    This is intentionally tiny and framework-owned. It lets Lilya compose both Lilya and
+    third-party ASGI middleware in an ASGI-compliant way without requiring every middleware
+    implementation to repeat the copy-before-mutate ceremony itself. Only Lilya-owned route
+    metadata is copied back for response-side middleware such as tracing.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        child_scope = copy_scope_for_middleware(scope)
+        await self.app(child_scope, receive, send)
+        for key in ROUTE_SCOPE_KEYS:
+            if key in child_scope:
+                scope[key] = child_scope[key]
+
+
+def apply_asgi_stack(app: ASGIApp, stack: Sequence[Any] | None) -> ASGIApp:
+    """
+    Compose ASGI middleware-like layers with scope isolation on both sides of each layer.
+
+    Each layer receives a copy of its parent's scope. The child application passed into that
+    layer also copies the layer's scope before continuing downstream. Downstream code still
+    sees the layer's additions, but downstream mutations cannot leak back into the layer's
+    response-side logic.
+
+    Controller classes are passed directly to the first wrapping layer so Lilya's middleware
+    and permission protocol metaclasses can keep their existing controller instantiation
+    behavior. Once the controller is behind that first layer, normal ASGI isolation resumes.
+    """
+    if stack is None:
+        return app
+
+    for cls, args, options in reversed(stack):
+        child_app = app if hasattr(app, "__is_controller__") else ScopeIsolationMiddleware(app)
+        app = ScopeIsolationMiddleware(cls(app=child_app, *args, **options))
+    return app

--- a/lilya/apps.py
+++ b/lilya/apps.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, ClassVar, ParamSpec, cast
 
 from lilya import status
 from lilya._internal._connection import Connection  # noqa
-from lilya._internal._middleware import wrap_middleware  # noqa
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware  # noqa
 from lilya._internal._permissions import wrap_permission  # noqa
 from lilya._utils import is_class_and_subclass
 from lilya.compat import import_string  # noqa
@@ -123,11 +123,7 @@ class BaseLilya:
                 DefineMiddleware(LilyaExceptionMiddleware, handlers=exception_handlers),
             )
 
-        app = self.router
-        for middleware_class, args, options in reversed(middleware):
-            app = middleware_class(app=app, *args, **options)
-
-        return app
+        return apply_asgi_stack(self.router, middleware)
 
     def _get_error_handler(self) -> Callable[[Request, Exception], Response] | None:
         """

--- a/lilya/routing/host.py
+++ b/lilya/routing/host.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from lilya._internal._middleware import wrap_middleware
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware
 from lilya._internal._path import compile_path, replace_params
 from lilya._internal._permissions import wrap_permission
 from lilya.compat import is_async_callable
@@ -87,9 +87,7 @@ class Host(BasePath):
         Returns:
             None
         """
-        if middleware is not None:
-            for cls, args, options in reversed(middleware):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, middleware)
 
     def _apply_permissions(self, permissions: Sequence[DefinePermission] | None) -> None:
         """
@@ -101,9 +99,7 @@ class Host(BasePath):
         Returns:
             None
         """
-        if permissions is not None:
-            for cls, args, options in reversed(permissions):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, permissions)
 
     @property
     def routes(self) -> list[BasePath]:

--- a/lilya/routing/include.py
+++ b/lilya/routing/include.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from lilya._internal._middleware import wrap_middleware
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware
 from lilya._internal._path import clean_path, compile_path, get_route_path, replace_params
 from lilya._internal._permissions import wrap_permission
 from lilya._internal._urls import include
@@ -175,9 +175,7 @@ class Include(BasePath):
         Returns:
             None
         """
-        if middleware is not None:
-            for cls, args, options in reversed(middleware):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, middleware)
 
     def _apply_permissions(self, permissions: Sequence[DefinePermission] | None) -> None:
         """
@@ -189,9 +187,7 @@ class Include(BasePath):
         Returns:
             None
         """
-        if permissions is not None:
-            for cls, args, options in reversed(permissions):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, permissions)
 
     @property
     def routes(self) -> list[BasePath]:

--- a/lilya/routing/path.py
+++ b/lilya/routing/path.py
@@ -12,7 +12,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 
-from lilya._internal._middleware import wrap_middleware
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware
 from lilya._internal._path import (
     clean_path,
     compile_path,
@@ -216,9 +216,7 @@ class Path(BaseHandler, BasePath):
         Returns:
             None
         """
-        if middleware is not None:
-            for cls, args, options in reversed(middleware):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, middleware)
 
     def _apply_permissions(self, permissions: Sequence[DefinePermission] | None) -> None:
         """
@@ -230,9 +228,7 @@ class Path(BaseHandler, BasePath):
         Returns:
             None
         """
-        if permissions is not None:
-            for cls, args, options in reversed(permissions):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, permissions)
 
     def path_for(self, name: str, /, **path_params: Any) -> URLPath:
         """

--- a/lilya/routing/router.py
+++ b/lilya/routing/router.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 from lilya import status
 from lilya._internal._events import AsyncLifespan, handle_lifespan_events
-from lilya._internal._middleware import wrap_middleware
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware
 from lilya._internal._path import get_route_path
 from lilya._internal._permissions import wrap_permission
 from lilya.compat import is_async_callable
@@ -182,9 +182,7 @@ class BaseRouter:
         Returns:
             None
         """
-        if middleware is not None:
-            for cls, args, options in reversed(middleware):
-                self.middleware_stack = cls(app=self.middleware_stack, *args, **options)
+        self.middleware_stack = apply_asgi_stack(self.middleware_stack, middleware)
 
     def _apply_permissions(self, permissions: Sequence[DefinePermission] | None) -> None:
         """
@@ -196,9 +194,7 @@ class BaseRouter:
         Returns:
             None
         """
-        if permissions is not None:
-            for cls, args, options in reversed(self.permissions):
-                self.middleware_stack = cls(app=self.middleware_stack, *args, **options)
+        self.middleware_stack = apply_asgi_stack(self.middleware_stack, permissions)
 
     def path_for(self, name: str, /, **path_params: Any) -> URLPath:
         return self.url_path_for(name, **path_params)

--- a/lilya/routing/websocket.py
+++ b/lilya/routing/websocket.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from lilya._internal._middleware import wrap_middleware
+from lilya._internal._middleware import apply_asgi_stack, wrap_middleware
 from lilya._internal._path import clean_path, compile_path, get_route_path, replace_params
 from lilya._internal._permissions import wrap_permission
 from lilya._internal._responses import BaseHandler
@@ -163,9 +163,7 @@ class WebSocketPath(BaseHandler, BasePath):
         Returns:
             None
         """
-        if middleware is not None:
-            for cls, args, options in reversed(middleware):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, middleware)
 
     def _apply_permissions(self, permissions: Sequence[DefinePermission] | None) -> None:
         """
@@ -177,9 +175,7 @@ class WebSocketPath(BaseHandler, BasePath):
         Returns:
             None
         """
-        if permissions is not None:
-            for cls, args, options in reversed(permissions):
-                self.app = cls(app=self.app, *args, **options)
+        self.app = apply_asgi_stack(self.app, permissions)
 
     def search(self, scope: Scope) -> tuple[Match, Scope]:
         """

--- a/tests/middleware/test_include_middleware_scope_isolation.py
+++ b/tests/middleware/test_include_middleware_scope_isolation.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request as FastAPIRequest
+from starlette.applications import Starlette
+from starlette.middleware.sessions import SessionMiddleware as StarletteSessionMiddleware
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import JSONResponse as StarletteJSONResponse
+from starlette.routing import Route
+
+from lilya.apps import ChildLilya, Lilya
+from lilya.authentication import AuthCredentials, AuthenticationBackend, BasicUser
+from lilya.middleware import DefineMiddleware
+from lilya.middleware.asyncexit import AsyncExitStackMiddleware
+from lilya.middleware.authentication import AuthenticationMiddleware
+from lilya.middleware.clientip import ClientIPMiddleware, ClientIPScopeOnlyMiddleware
+from lilya.middleware.exceptions import ExceptionMiddleware
+from lilya.middleware.sessions import SessionMiddleware
+from lilya.middleware.trustedhost import TrustedHostMiddleware
+from lilya.middleware.trustedreferrer import TrustedReferrerMiddleware
+from lilya.requests import Connection, Request
+from lilya.responses import JSONResponse
+from lilya.routing import Include, Path
+from lilya.testclient import TestClient
+from lilya.types import ASGIApp, Message, Receive, Scope, Send
+
+TestClientFactory = Callable[..., TestClient]
+
+MISSING = "__missing__"
+
+
+class SessionSnapshotMiddleware:
+    def __init__(self, app: ASGIApp, header: str) -> None:
+        self.app = app
+        self.header = header.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                owner = scope.get("session", {}).get("owner", MISSING)
+                message["headers"] = [
+                    *message["headers"],
+                    (self.header, str(owner).encode("latin-1")),
+                ]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class OuterScopeObserverMiddleware:
+    def __init__(self, app: ASGIApp, key: str, header: str = "x-upstream-scope") -> None:
+        self.app = app
+        self.key = key
+        self.header = header.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message["headers"] = [
+                    *message["headers"],
+                    (self.header, _scope_value(scope, self.key).encode("latin-1")),
+                ]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class OuterHeaderObserverMiddleware:
+    def __init__(self, app: ASGIApp, header_name: str, header: str = "x-upstream-header") -> None:
+        self.app = app
+        self.header_name = header_name.lower()
+        self.header = header.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message["headers"] = [
+                    *message["headers"],
+                    (
+                        self.header,
+                        _request_header_value(scope, self.header_name).encode("latin-1"),
+                    ),
+                ]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class FixedAuthBackend(AuthenticationBackend):
+    async def authenticate(self, request: Connection) -> tuple[AuthCredentials, BasicUser]:
+        return AuthCredentials(["authenticated"]), BasicUser("scoped-user")
+
+
+async def lilya_session_view(request: Request) -> JSONResponse:
+    return JSONResponse({"session": request.session})
+
+
+async def raw_session_view(scope: Scope, receive: Receive, send: Send) -> None:
+    response = JSONResponse({"session": scope.get("session", {})})
+    await response(scope, receive, send)
+
+
+async def starlette_session_set(request: StarletteRequest) -> StarletteJSONResponse:
+    request.session["owner"] = "starlette"
+    return StarletteJSONResponse({"session": request.session})
+
+
+async def scope_echo(request: Request) -> JSONResponse:
+    return JSONResponse(
+        {
+            "auth": _scope_value(request.scope, "auth"),
+            "clientip": _scope_value(request.scope, ClientIPScopeOnlyMiddleware.scope_name),
+            "exception_handlers": request.scope.get("lilya.exception_handlers") is not None,
+            "host": _scope_value(request.scope, TrustedHostMiddleware.scope_flag_name),
+            "referrer": _scope_value(request.scope, TrustedReferrerMiddleware.scope_flag_name),
+            "stack": request.scope.get("lilya_asyncexitstack") is not None,
+            "user": _scope_value(request.scope, "user"),
+            "x_real_ip": request.headers.get("x-real-ip", MISSING),
+        }
+    )
+
+
+def _scope_value(scope: Scope, key: str) -> str:
+    value = scope.get(key, MISSING)
+    if key == "auth" and value is not MISSING:
+        return ",".join(value.scopes)
+    if key == "user" and value is not MISSING:
+        return value.display_name
+    return str(value)
+
+
+def _request_header_value(scope: Scope, header_name: str) -> str:
+    headers = scope.get("headers", [])
+    if hasattr(headers, "get"):
+        return str(headers.get(header_name, MISSING))
+    for key, value in headers:
+        key = key.decode("latin-1") if isinstance(key, bytes) else key
+        if key.lower() == header_name:
+            return value.decode("latin-1") if isinstance(value, bytes) else value
+    return MISSING
+
+
+def _session_middleware(owner: str) -> DefineMiddleware:
+    return DefineMiddleware(
+        SessionMiddleware,
+        secret_key=f"{owner}-secret",
+        populate_session=lambda connection: {"owner": owner},
+    )
+
+
+def _include_session_middleware(owner: str, snapshot_header: str) -> list[DefineMiddleware]:
+    return [
+        _session_middleware(owner),
+        DefineMiddleware(SessionSnapshotMiddleware, header=snapshot_header),
+    ]
+
+
+def test_include_session_does_not_leak_child_lilya_session_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    child = ChildLilya(
+        routes=[Path("/view", lilya_session_view)],
+        middleware=[_session_middleware("child")],
+    )
+    app = Lilya(
+        routes=[
+            Include(
+                "/child",
+                app=child,
+                middleware=_include_session_middleware("include", "x-include-session-owner"),
+            )
+        ]
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/child/view")
+
+    assert response.json() == {"session": {"owner": "child"}}
+    assert response.headers["x-include-session-owner"] == "include"
+
+
+def test_three_nested_lilya_session_middlewares_keep_their_own_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    leaf = ChildLilya(
+        routes=[Path("/view", lilya_session_view)],
+        middleware=[_session_middleware("leaf")],
+    )
+    middle = ChildLilya(
+        routes=[Include("/leaf", app=leaf)],
+        middleware=_include_session_middleware("middle", "x-middle-session-owner"),
+    )
+    app = Lilya(
+        routes=[
+            Include(
+                "/middle",
+                app=middle,
+                middleware=_include_session_middleware("root", "x-root-session-owner"),
+            )
+        ]
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/middle/leaf/view")
+
+    assert response.json() == {"session": {"owner": "leaf"}}
+    assert response.headers["x-middle-session-owner"] == "middle"
+    assert response.headers["x-root-session-owner"] == "root"
+
+
+def test_include_session_does_not_leak_raw_asgi_session_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    raw_child = SessionMiddleware(
+        raw_session_view,
+        secret_key="raw-secret",
+        populate_session=lambda c: {"owner": "raw"},
+    )
+    app = Lilya(
+        routes=[
+            Include(
+                "/raw",
+                app=raw_child,
+                middleware=_include_session_middleware("include", "x-include-session-owner"),
+            )
+        ]
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/raw/view")
+
+    assert response.json() == {"session": {"owner": "raw"}}
+    assert response.headers["x-include-session-owner"] == "include"
+
+
+def test_include_session_preserves_starlette_child_session_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    starlette_app = Starlette(routes=[Route("/set", starlette_session_set, methods=["POST"])])
+    starlette_app.add_middleware(StarletteSessionMiddleware, secret_key="starlette-secret")
+    app = Lilya(
+        routes=[
+            Include(
+                "/starlette",
+                app=starlette_app,
+                middleware=_include_session_middleware("include", "x-include-session-owner"),
+            )
+        ]
+    )
+    client = test_client_factory(app)
+
+    response = client.post("/starlette/set")
+
+    assert response.json() == {"session": {"owner": "starlette"}}
+    assert response.headers["x-include-session-owner"] == "include"
+
+
+def test_include_session_preserves_fastapi_child_session_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    fastapi_app = FastAPI()
+    fastapi_app.add_middleware(StarletteSessionMiddleware, secret_key="fastapi-secret")
+
+    @fastapi_app.post("/set")
+    async def fastapi_session_set(request: FastAPIRequest) -> dict[str, dict[str, Any]]:
+        request.session["owner"] = "fastapi"
+        return {"session": request.session}
+
+    app = Lilya(
+        routes=[
+            Include(
+                "/fastapi",
+                app=fastapi_app,
+                middleware=_include_session_middleware("include", "x-include-session-owner"),
+            )
+        ]
+    )
+    client = test_client_factory(app)
+
+    response = client.post("/fastapi/set")
+
+    assert response.json() == {"session": {"owner": "fastapi"}}
+    assert response.headers["x-include-session-owner"] == "include"
+
+
+@pytest.mark.parametrize(
+    ("middleware", "scope_key", "response_key", "expected"),
+    [
+        (
+            [DefineMiddleware(AuthenticationMiddleware, backend=FixedAuthBackend())],
+            "user",
+            "user",
+            "scoped-user",
+        ),
+        (
+            [DefineMiddleware(ClientIPScopeOnlyMiddleware, trusted_proxies=["unix"])],
+            ClientIPScopeOnlyMiddleware.scope_name,
+            "clientip",
+            "203.0.113.10",
+        ),
+        (
+            [DefineMiddleware(ExceptionMiddleware)],
+            "lilya.exception_handlers",
+            "exception_handlers",
+            True,
+        ),
+        (
+            [DefineMiddleware(TrustedHostMiddleware, allowed_hosts=["testserver"])],
+            TrustedHostMiddleware.scope_flag_name,
+            "host",
+            "True",
+        ),
+        (
+            [DefineMiddleware(TrustedReferrerMiddleware, allowed_referrers=[""])],
+            TrustedReferrerMiddleware.scope_flag_name,
+            "referrer",
+            "True",
+        ),
+        (
+            [DefineMiddleware(AsyncExitStackMiddleware)],
+            "lilya_asyncexitstack",
+            "stack",
+            True,
+        ),
+    ],
+)
+def test_scope_writing_middlewares_do_not_leak_to_upstream_scope(
+    test_client_factory: TestClientFactory,
+    middleware: Sequence[DefineMiddleware],
+    scope_key: str,
+    response_key: str,
+    expected: Any,
+) -> None:
+    app = Lilya(
+        routes=[Path("/", scope_echo)],
+        middleware=[
+            DefineMiddleware(OuterScopeObserverMiddleware, key=scope_key),
+            *middleware,
+        ],
+    )
+    client = test_client_factory(app)
+
+    headers = {"x-forwarded-for": "203.0.113.10"} if response_key == "clientip" else None
+    response = client.get("/", headers=headers)
+
+    assert response.json()[response_key] == expected
+    assert response.headers["x-upstream-scope"] == MISSING
+
+
+def test_clientip_header_middleware_does_not_leak_header_to_upstream_scope(
+    test_client_factory: TestClientFactory,
+) -> None:
+    app = Lilya(
+        routes=[Path("/", scope_echo)],
+        middleware=[
+            DefineMiddleware(OuterHeaderObserverMiddleware, header_name="x-real-ip"),
+            DefineMiddleware(ClientIPMiddleware, trusted_proxies=["unix"]),
+        ],
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/", headers={"x-forwarded-for": "203.0.113.10"})
+
+    assert response.json()["x_real_ip"] == "203.0.113.10"
+    assert response.headers["x-upstream-header"] == MISSING

--- a/tests/middleware/test_include_middleware_scope_isolation.py
+++ b/tests/middleware/test_include_middleware_scope_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -11,6 +12,7 @@ from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
 from starlette.routing import Route
 
+from lilya._internal._middleware import ScopeIsolationMiddleware
 from lilya.apps import ChildLilya, Lilya
 from lilya.authentication import AuthCredentials, AuthenticationBackend, BasicUser
 from lilya.middleware import DefineMiddleware
@@ -21,6 +23,8 @@ from lilya.middleware.exceptions import ExceptionMiddleware
 from lilya.middleware.sessions import SessionMiddleware
 from lilya.middleware.trustedhost import TrustedHostMiddleware
 from lilya.middleware.trustedreferrer import TrustedReferrerMiddleware
+from lilya.permissions import DefinePermission
+from lilya.protocols.permissions import PermissionProtocol
 from lilya.requests import Connection, Request
 from lilya.responses import JSONResponse
 from lilya.routing import Include, Path
@@ -89,6 +93,48 @@ class OuterHeaderObserverMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
+class RouteTemplateSnapshotMiddleware:
+    def __init__(self, app: ASGIApp, header: str = "x-route-template") -> None:
+        self.app = app
+        self.header = header.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message["headers"] = [
+                    *message["headers"],
+                    (
+                        self.header,
+                        str(scope.get("route_path_template", MISSING)).encode("latin-1"),
+                    ),
+                ]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class PositionalScopeMiddleware:
+    def __init__(self, app: ASGIApp, key: str, value: str) -> None:
+        self.app = app
+        self.key = key
+        self.value = value
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope[self.key] = self.value
+        await self.app(scope, receive, send)
+
+
+class PositionalScopePermission(PermissionProtocol):
+    def __init__(self, app: ASGIApp, key: str, value: str) -> None:
+        self.app = app
+        self.key = key
+        self.value = value
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope[self.key] = self.value
+        await self.app(scope, receive, send)
+
+
 class FixedAuthBackend(AuthenticationBackend):
     async def authenticate(self, request: Connection) -> tuple[AuthCredentials, BasicUser]:
         return AuthCredentials(["authenticated"]), BasicUser("scoped-user")
@@ -119,6 +165,15 @@ async def scope_echo(request: Request) -> JSONResponse:
             "stack": request.scope.get("lilya_asyncexitstack") is not None,
             "user": _scope_value(request.scope, "user"),
             "x_real_ip": request.headers.get("x-real-ip", MISSING),
+        }
+    )
+
+
+async def positional_scope_echo(request: Request) -> JSONResponse:
+    return JSONResponse(
+        {
+            "middleware": request.scope.get("middleware_positional", MISSING),
+            "permission": request.scope.get("permission_positional", MISSING),
         }
     )
 
@@ -284,6 +339,71 @@ def test_include_session_preserves_fastapi_child_session_scope(
 
     assert response.json() == {"session": {"owner": "fastapi"}}
     assert response.headers["x-include-session-owner"] == "include"
+
+
+def test_route_metadata_is_available_to_response_side_middleware(
+    test_client_factory: TestClientFactory,
+) -> None:
+    app = Lilya(
+        routes=[Path("/items/{item_id}", scope_echo)],
+        middleware=[DefineMiddleware(RouteTemplateSnapshotMiddleware)],
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/items/123")
+
+    assert response.status_code == 200
+    assert response.headers["x-route-template"] == "/items/{item_id}"
+
+
+def test_route_metadata_is_preserved_when_child_raises() -> None:
+    async def raising_app(scope: Scope, receive: Receive, send: Send) -> None:
+        scope["route_path_template"] = "/raised"
+        raise RuntimeError("boom")
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Message) -> None:
+        pass
+
+    scope: Scope = {"type": "http", "headers": []}
+    isolated_app = ScopeIsolationMiddleware(raising_app)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(isolated_app(scope, receive, send))
+
+    assert scope["route_path_template"] == "/raised"
+
+
+def test_middleware_and_permission_positional_arguments_are_supported(
+    test_client_factory: TestClientFactory,
+) -> None:
+    app = Lilya(
+        routes=[Path("/", positional_scope_echo)],
+        middleware=[
+            DefineMiddleware(
+                PositionalScopeMiddleware,
+                "middleware_positional",
+                "middleware-value",
+            )
+        ],
+        permissions=[
+            DefinePermission(
+                PositionalScopePermission,
+                "permission_positional",
+                "permission-value",
+            )
+        ],
+    )
+    client = test_client_factory(app)
+
+    response = client.get("/")
+
+    assert response.json() == {
+        "middleware": "middleware-value",
+        "permission": "permission-value",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/middleware/test_include_middleware_scope_isolation.py
+++ b/tests/middleware/test_include_middleware_scope_isolation.py
@@ -376,6 +376,39 @@ def test_route_metadata_is_preserved_when_child_raises() -> None:
     assert scope["route_path_template"] == "/raised"
 
 
+def test_route_metadata_syncs_once_for_streaming_messages() -> None:
+    sync_count = 0
+
+    class CountingScopeIsolationMiddleware(ScopeIsolationMiddleware):
+        def sync_route_metadata(self, source_scope: Scope, target_scope: Scope) -> None:
+            nonlocal sync_count
+            sync_count += 1
+            super().sync_route_metadata(source_scope, target_scope)
+
+    async def streaming_app(scope: Scope, receive: Receive, send: Send) -> None:
+        scope["route_path_template"] = "/stream"
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"one", "more_body": True})
+        await send({"type": "http.response.body", "body": b"two", "more_body": False})
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    observed_route_templates = []
+
+    async def send(message: Message) -> None:
+        observed_route_templates.append(scope.get("route_path_template", MISSING))
+
+    scope: Scope = {"type": "http", "headers": []}
+    isolated_app = CountingScopeIsolationMiddleware(streaming_app)
+
+    asyncio.run(isolated_app(scope, receive, send))
+
+    assert observed_route_templates == ["/stream", "/stream", "/stream"]
+    assert scope["route_path_template"] == "/stream"
+    assert sync_count == 2
+
+
 def test_middleware_and_permission_positional_arguments_are_supported(
     test_client_factory: TestClientFactory,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes ASGI `scope` mutation leaks across Lilya middleware, permission, include, route, host, and websocket stack boundaries.

This surfaced with nested apps that both install `SessionMiddleware`: the child app could overwrite `scope["session"]`, and the parent/include middleware would then resume response handling with the child session instead of its own. The same class of issue can affect any middleware that writes shared scope keys.

## Context

This is a subtle ASGI edge case that is rarely exercised directly and easy to miss in framework implementations. It only becomes visible when nested ASGI apps each have middleware that mutates the same `scope` key, especially when an outer middleware reads that key again while sending the response.

The ASGI spec recommends copying the scope before mutating it and passing it downstream, since otherwise changes may leak upstream. Testing against representative third-party ASGI apps/frameworks showed this failure mode is not unique to Lilya, so this change makes Lilya defensive at its own composition boundaries.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/lilya/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

