### PR TITLE
Update test suite to include Python 3.15

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 
     services:
       postgres:
@@ -47,6 +47,7 @@ jobs:
       - uses: "actions/setup-python@v7"
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
       - uses: actions/cache@v6
         id: cache
         with:
@@ -62,8 +63,10 @@ jobs:
       #    pip-audit --strict --desc
       - uses: pre-commit/action@v3.0.1
       - name: "Run linting checks"
+        if: "matrix.python-version != '3.15'"
         run: "hatch fmt --check"
       - name: "Run typing checks"
+        if: "matrix.python-version != '3.15'"
         run: "hatch run test:check_types"
       - name: "Run tests (non-CLI, parallel)"
         run: "hatch run test:test_non_cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]


### PR DESCRIPTION
Added Python 3.15 to the testing matrix and adjusted linting and typing checks to skip for this version.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/lilya/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

